### PR TITLE
Deleted Redundant Decision

### DIFF
--- a/decisions/_MIS_Dutch.txt
+++ b/decisions/_MIS_Dutch.txt
@@ -70,35 +70,9 @@ country_decisions = {
 		}
 	}
 	
-	
-	development_of_amsterdam = {
-		potential = {
-			OR = {
-				tag = HOL
-				tag = NED
-			}
-			97 = {
-				NOT = { has_province_modifier = holland_polders }
-			}
-		}
-		allow = {
-			owns_core_province = 97 #Amsterdam
-			adm_tech = 13 # Improved Drainage
-			adm_power = 50
-		}
-		effect = {
-			add_adm_power = -50
-			97 = {
-				add_permanent_province_modifier = {
-					name = "holland_polders"
-					duration = -1
-				}
-			}
-		}
-		ai_will_do = {
-			factor = 1
-		}
-	}
+	#######################################################################################################################################################################
+	#Original Event from vanilla was repeated here, nothing changed gameplay wise, but fixed decisions screen not scrolling down when there is more decisions then it fits#
+	#######################################################################################################################################################################
 	
 	amsterdam_canals = {
 		potential = {


### PR DESCRIPTION
For some reason the duplication of the call to a vanilla event modifier makes the decisions listbox scroll go bork so I deleted the duplicated decision and since it gives the same bonuses to the tag as the vanilla one no a problem deleting it. Probably the person who made this didn't pay attention when moving the decision to this file.