### PR TITLE
Further work on the vanilla start date

### DIFF
--- a/history/provinces/1231 - Aswan.txt
+++ b/history/provinces/1231 - Aswan.txt
@@ -25,6 +25,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = SAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1232 - Suakin.txt
+++ b/history/provinces/1232 - Suakin.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = ABB # weird
     
     #culture = english
     #religion = catholic

--- a/history/provinces/129 - Krain.txt
+++ b/history/provinces/129 - Krain.txt
@@ -29,6 +29,7 @@ discovered_by = QAS
     controller = HAB
 
     add_core = HAB
+    add_core = STY
     
     #culture = english
     #religion = catholic

--- a/history/provinces/130 - Istria.txt
+++ b/history/provinces/130 - Istria.txt
@@ -35,6 +35,7 @@ discovered_by = ottoman
     controller = VEN
 
     add_core = VEN
+    remove_core = RIE
     
     #culture = 
     #religion = 

--- a/history/provinces/145 - Morea.txt
+++ b/history/provinces/145 - Morea.txt
@@ -29,6 +29,7 @@ discovered_by = nomad_group
     controller = BYZ
 
     add_core = BYZ
+    remove_core = ATH
     
     #culture = english
     religion = orthodox

--- a/history/provinces/148 - Thessaloniki.txt
+++ b/history/provinces/148 - Thessaloniki.txt
@@ -27,6 +27,7 @@ center_of_trade = 2
     controller = TUR
     add_core = BYZ
     add_core = TUR
+    remove_core = MAC
     
     #culture = english
     #religion = catholic

--- a/history/provinces/155 - Bekes.txt
+++ b/history/provinces/155 - Bekes.txt
@@ -28,8 +28,9 @@ discovered_by = ottoman
     controller = HUN
 
     add_core = HUN
+    remove_core = CUM
     
-    #culture = english
+    culture = hungarian
     religion = catholic
     
 }

--- a/history/provinces/156 - Temes.txt
+++ b/history/provinces/156 - Temes.txt
@@ -29,6 +29,8 @@ discovered_by = ottoman
     controller = HUN
 
     add_core = HUN
+    add_core = TRA
+    remove_core = CUM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/159 - Silistria.txt
+++ b/history/provinces/159 - Silistria.txt
@@ -23,6 +23,8 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
+    add_core = BUL
+    remove_core = KRV
     
     #culture = english
     religion = orthodox

--- a/history/provinces/164 - Naxos.txt
+++ b/history/provinces/164 - Naxos.txt
@@ -23,6 +23,7 @@ discovered_by = western
     controller = NAX
 
     add_core = NAX
+    remove_core = AEG
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1766 - Kosovo.txt
+++ b/history/provinces/1766 - Kosovo.txt
@@ -33,6 +33,7 @@ discovered_by = ottoman
     controller = SER
 
     add_core = SER
+    remove_core = SKJ
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1769 - Gorz.txt
+++ b/history/provinces/1769 - Gorz.txt
@@ -25,6 +25,8 @@ discovered_by = ottoman
     controller = HAB
 
     add_core = HAB
+    add_core = STY
+    remove_core = RIE
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1773 - Achaea.txt
+++ b/history/provinces/1773 - Achaea.txt
@@ -30,6 +30,7 @@ discovered_by = nomad_group
     controller = BYZ
 
     add_core = BYZ
+    remove_core = ATH
     
     #culture = english
     religion = orthodox

--- a/history/provinces/1848 - Hamid.txt
+++ b/history/provinces/1848 - Hamid.txt
@@ -25,6 +25,7 @@ discovered_by = nomad_group
 
     add_core = TUR
     add_core = KAR
+    remove_core = MEN
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1853- Kastoria.txt
+++ b/history/provinces/1853- Kastoria.txt
@@ -25,6 +25,7 @@ discovered_by = nomad_group
     controller = TUR
     add_core = BYZ
     add_core = TUR
+    remove_core = MAC
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1854 - Nablus.txt
+++ b/history/provinces/1854 - Nablus.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = KOJ
     
     #culture = english
     religion = sunni

--- a/history/provinces/1855 - Sidon.txt
+++ b/history/provinces/1855 - Sidon.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    add_core = SYR
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1940 - Belz.txt
+++ b/history/provinces/1940 - Belz.txt
@@ -28,6 +28,8 @@ discovered_by = ottoman
     controller = MAZ
 
     add_core = MAZ
+    add_core = VOL
+    remove_core = GLA
     
     #culture = english
     #religion = catholic

--- a/history/provinces/1954 - Torontal.txt
+++ b/history/provinces/1954 - Torontal.txt
@@ -29,8 +29,9 @@ discovered_by = ottoman
     controller = HUN
 
     add_core = HUN
+    remove_core = CUM
     
-    #culture = english
+    culture = hungarian
     religion = catholic
     
 }

--- a/history/provinces/2297 - Saruhan.txt
+++ b/history/provinces/2297 - Saruhan.txt
@@ -24,7 +24,9 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
-    
+    add_core = SRU
+    remove_core = AYD
+
     #culture = english
     #religion = catholic
     

--- a/history/provinces/2299 - Bolu.txt
+++ b/history/provinces/2299 - Bolu.txt
@@ -29,6 +29,8 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
+    add_core = CND
+    remove_core = OSM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2301 - Kayseri.txt
+++ b/history/provinces/2301 - Kayseri.txt
@@ -20,5 +20,7 @@ discovered_by = ottoman
 discovered_by = nomad_group
 
 1444.11.9 = {
-    religion = sunni
+
+    add_core = ERE
+    #religion = sunni # Decided to keep them orthodox for a little extra flavor
 }

--- a/history/provinces/2302 - Icel.txt
+++ b/history/provinces/2302 - Icel.txt
@@ -25,6 +25,7 @@ discovered_by = nomad_group
     controller = KAR
 
     add_core = KAR
+    remove_core = RAM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2304 - Canik.txt
+++ b/history/provinces/2304 - Canik.txt
@@ -2,8 +2,8 @@
 
 owner = CND
 controller = CND
-culture = turkish
-religion = sunni
+culture = pontic_greek
+religion = orthodox
 capital = "Samsun"
 trade_goods = wine
 hre = no

--- a/history/provinces/2305 - Erzincan.txt
+++ b/history/provinces/2305 - Erzincan.txt
@@ -17,3 +17,7 @@ discovered_by = eastern
 discovered_by = muslim
 discovered_by = ottoman
 discovered_by = nomad_group
+
+1444.11.9 = {
+	add_core = ERE
+}

--- a/history/provinces/2308 - Urfa.txt
+++ b/history/provinces/2308 - Urfa.txt
@@ -24,4 +24,5 @@ discovered_by = indian
 	owner = AKK
 	controller = AKK
 	add_core = AKK
+	remove_core = DUL
 }

--- a/history/provinces/2313 - Antioch.txt
+++ b/history/provinces/2313 - Antioch.txt
@@ -26,6 +26,8 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    add_core = SYR
+    remove_core = ATC
     
     #culture = english
     religion = sunni

--- a/history/provinces/2314 - Rahba.txt
+++ b/history/provinces/2314 - Rahba.txt
@@ -22,6 +22,8 @@ discovered_by = east_african
 	owner = QAR
 	controller = QAR
 	add_core = QAR
+	add_core = SYR
 	add_core = FAD
+	remove_core = ASR
 	religion = sunni
 }

--- a/history/provinces/2315 - Suez.txt
+++ b/history/provinces/2315 - Suez.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = TKT
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2316 - Al Gharbia.txt
+++ b/history/provinces/2316 - Al Gharbia.txt
@@ -33,6 +33,7 @@ add_permanent_province_modifier = {
     controller = MAM
 
     add_core = MAM
+    remove_core = CAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2317 - Minya.txt
+++ b/history/provinces/2317 - Minya.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = BNS
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2319 - Manfalut.txt
+++ b/history/provinces/2319 - Manfalut.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = SAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2320 - Ras Gharib.txt
+++ b/history/provinces/2320 - Ras Gharib.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = SAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2321 - Queseer.txt
+++ b/history/provinces/2321 - Queseer.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = SAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2324 - Halaib.txt
+++ b/history/provinces/2324 - Halaib.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = ABB # what was that?
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2325 - Tarrana.txt
+++ b/history/provinces/2325 - Tarrana.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = CYR
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2326 - Bardiyah.txt
+++ b/history/provinces/2326 - Bardiyah.txt
@@ -24,6 +24,7 @@ discovered_by = nomad_group
     controller = MAM
 
     add_core = MAM
+    remove_core = CYR
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2348 - Chios.txt
+++ b/history/provinces/2348 - Chios.txt
@@ -24,6 +24,7 @@ discovered_by = western
     controller = GEN
 
     add_core = GEN
+    remove_core = AEG
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2413 - Tyn.txt
+++ b/history/provinces/2413 - Tyn.txt
@@ -28,6 +28,7 @@ discovered_by = nomad_group
     controller = CRI
 
     add_core = CRI
+    remove_core = AZV
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2414 - Azaraba.txt
+++ b/history/provinces/2414 - Azaraba.txt
@@ -25,9 +25,10 @@ discovered_by = nomad_group
     controller = CRI
 
     add_core = CRI
+    remove_core = AZV
     
     #culture = english
-    #religion = catholic
+    religion = sunni # historical
     
 }
 

--- a/history/provinces/2424 - Peremyshl.txt
+++ b/history/provinces/2424 - Peremyshl.txt
@@ -28,6 +28,8 @@ discovered_by = muslim
     controller = POL
 
     add_core = POL
+    add_core = VOL
+    remove_core = GLA
     
     #culture = english
     #religion = catholic

--- a/history/provinces/261 - Halicz.txt
+++ b/history/provinces/261 - Halicz.txt
@@ -29,6 +29,8 @@ discovered_by = ottoman
     controller = POL
 
     add_core = POL
+    add_core = VOL
+    remove_core = GLA
     
     #culture = english
     #religion = catholic

--- a/history/provinces/279 - Volhynia.txt
+++ b/history/provinces/279 - Volhynia.txt
@@ -25,6 +25,8 @@ discovered_by = nomad_group
     controller = LIT
 
     add_core = LIT
+    add_core = VOL
+    remove_core = VLH
     
     #culture = english
     #religion = catholic

--- a/history/provinces/281 - Kamienec.txt
+++ b/history/provinces/281 - Kamienec.txt
@@ -25,6 +25,8 @@ discovered_by = nomad_group
     controller = POL
 
     add_core = POL
+    add_core = VOL
+    remove_core = VLH
     
     #culture = english
     #religion = catholic

--- a/history/provinces/286 - Azow.txt
+++ b/history/provinces/286 - Azow.txt
@@ -31,6 +31,7 @@ add_permanent_province_modifier = {
     controller = GEN
 
     add_core = GEN
+    remove_core = AZV
     
     #culture = english
     #religion = catholic

--- a/history/provinces/287 - Kouban.txt
+++ b/history/provinces/287 - Kouban.txt
@@ -25,9 +25,10 @@ discovered_by = nomad_group
     controller = CRI
 
     add_core = CRI
+    remove_core = AZV
     
     #culture = english
-    #religion = catholic
+    religion = sunni # historical
     
 }
 

--- a/history/provinces/2961 - Lwow.txt
+++ b/history/provinces/2961 - Lwow.txt
@@ -34,6 +34,8 @@ center_of_trade = 1
     controller = POL
 
     add_core = POL
+    add_core = VOL
+    remove_core = GLA
     
     #culture = english
     #religion = catholic

--- a/history/provinces/2962 - Rowne.txt
+++ b/history/provinces/2962 - Rowne.txt
@@ -24,6 +24,8 @@ discovered_by = nomad_group
     controller = LIT
 
     add_core = LIT
+    add_core = VOL
+    remove_core = VLH
     
     #culture = english
     #religion = catholic

--- a/history/provinces/3001 - Skopje.txt
+++ b/history/provinces/3001 - Skopje.txt
@@ -30,6 +30,8 @@ discovered_by = nomad_group
 
     add_core = TUR
     add_core = SER
+    add_core = BUL
+    remove_core = SKJ
     
     #culture = english
     #religion = catholic

--- a/history/provinces/3003 - Euboea.txt
+++ b/history/provinces/3003 - Euboea.txt
@@ -24,6 +24,7 @@ discovered_by = western
     controller = VEN
 
     add_core = VEN
+    remove_core = AEG
     
     #culture = english
     #religion = catholic

--- a/history/provinces/316 - Kocaeli.txt
+++ b/history/provinces/316 - Kocaeli.txt
@@ -27,6 +27,7 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
+    remove_core = OSM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/317 - Hudavendigar.txt
+++ b/history/provinces/317 - Hudavendigar.txt
@@ -26,6 +26,7 @@ center_of_trade = 2
     controller = TUR
 
     add_core = TUR
+    remove_core = OSM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/318 - Sugla.txt
+++ b/history/provinces/318 - Sugla.txt
@@ -2,8 +2,8 @@
 
 owner = AYD
 controller = AYD
-culture = turkish #Should not be Greek or Orthodox in 1444. Its status as a majority Greek city dates to at least after the 17th Century
-religion = sunni
+culture = greek
+religion = orthodox
 capital = "Izmirni"
 trade_goods = cotton #Major producer and exporter of Cotton
 hre = no

--- a/history/provinces/326 - Ankara.txt
+++ b/history/provinces/326 - Ankara.txt
@@ -24,6 +24,8 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
+    add_core = GRM
+    remove_core = OSM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/328 - Sinop.txt
+++ b/history/provinces/328 - Sinop.txt
@@ -2,8 +2,8 @@
 
 owner = CND
 controller = CND
-culture = turkish
-religion = sunni
+culture = pontic_greek
+religion = orthodox
 capital = "Sinop"
 trade_goods = naval_supplies
 hre = no

--- a/history/provinces/356 - Benghazi.txt
+++ b/history/provinces/356 - Benghazi.txt
@@ -27,6 +27,7 @@ center_of_trade = 1
     controller = MAM
 
     add_core = MAM
+    remove_core = CYR
     
     #culture = english
     #religion = catholic

--- a/history/provinces/357 - Darnah.txt
+++ b/history/provinces/357 - Darnah.txt
@@ -24,6 +24,7 @@ discovered_by = nomad_group
     controller = MAM
 
     add_core = MAM
+    remove_core = CYR
     
     #culture = english
     #religion = catholic

--- a/history/provinces/358 - Alexandria.txt
+++ b/history/provinces/358 - Alexandria.txt
@@ -30,6 +30,7 @@ center_of_trade = 1
     controller = MAM
 
     add_core = MAM
+    remove_core = ALX
     
     #culture = english
     religion = sunni

--- a/history/provinces/359 - Faiyum.txt
+++ b/history/provinces/359 - Faiyum.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = BNS
     
     #culture = english
     #religion = catholic

--- a/history/provinces/360 - Qena.txt
+++ b/history/provinces/360 - Qena.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = SAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/361 - Cairo.txt
+++ b/history/provinces/361 - Cairo.txt
@@ -28,6 +28,7 @@ center_of_trade = 2
     controller = MAM
 
     add_core = MAM
+    remove_core = CAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/362 - Rosetta.txt
+++ b/history/provinces/362 - Rosetta.txt
@@ -37,6 +37,7 @@ add_permanent_province_modifier = {
     controller = MAM
 
     add_core = MAM
+    remove_core = ALX
     
     #culture = english
     religion = sunni

--- a/history/provinces/363 - Damietta.txt
+++ b/history/provinces/363 - Damietta.txt
@@ -37,6 +37,7 @@ add_permanent_province_modifier = {
     controller = MAM
 
     add_core = MAM
+    remove_core = ALX
     
     #culture = english
     religion = sunni

--- a/history/provinces/364 - Gaza.txt
+++ b/history/provinces/364 - Gaza.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = KOJ
     
     #culture = english
     #religion = catholic

--- a/history/provinces/365 - Sinai.txt
+++ b/history/provinces/365 - Sinai.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = TKT
     
     #culture = english
     #religion = catholic

--- a/history/provinces/377 - Aleppo.txt
+++ b/history/provinces/377 - Aleppo.txt
@@ -29,6 +29,8 @@ center_of_trade = 2
     controller = MAM
 
     add_core = MAM
+    add_core = SYR
+    remove_core = ATC
     
     #culture = english
     #religion = catholic

--- a/history/provinces/378 - Tripoli.txt
+++ b/history/provinces/378 - Tripoli.txt
@@ -29,6 +29,7 @@ center_of_trade = 1
     controller = MAM
 
     add_core = MAM
+    add_core = SYR
     
     #culture = english
     #religion = catholic

--- a/history/provinces/379 - Jerusalem.txt
+++ b/history/provinces/379 - Jerusalem.txt
@@ -28,6 +28,7 @@ add_province_triggered_modifier = jerusalem_held
     controller = MAM
 
     add_core = MAM
+    remove_core = KOJ
     
     #culture = english
     religion = sunni

--- a/history/provinces/383 - Tabuk.txt
+++ b/history/provinces/383 - Tabuk.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = TBU
     
     #culture = english
     #religion = catholic

--- a/history/provinces/405 - Tadmor.txt
+++ b/history/provinces/405 - Tadmor.txt
@@ -18,6 +18,15 @@ discovered_by = ottoman
 discovered_by = indian
 discovered_by = nomad_group
 
+1444.11.9 = { 
+
+    add_core = SYR
+    
+    #culture = english
+    #religion = catholic
+    
+}
+
 1515.1.1 = { discovered_by = POR }
 1516.8.24 = {
 	owner = TUR

--- a/history/provinces/407 - Ar Raqqa.txt
+++ b/history/provinces/407 - Ar Raqqa.txt
@@ -25,5 +25,7 @@ discovered_by = indian
 	owner = AKK
 	controller = AKK
 	add_core = AKK
+	add_core = SYR
+	remove_core = ASR
 	religion = sunni
 }

--- a/history/provinces/4126 - Bacs.txt
+++ b/history/provinces/4126 - Bacs.txt
@@ -28,8 +28,9 @@ discovered_by = ottoman
     controller = HUN
 
     add_core = HUN
+    remove_core = CUM
     
-    #culture = english
+    culture = hungarian
     #religion = catholic
     
 }

--- a/history/provinces/4173 - Syrmia.txt
+++ b/history/provinces/4173 - Syrmia.txt
@@ -29,8 +29,9 @@ discovered_by = ottoman
 
     add_core = HUN
     add_core = SER
+    remove_core = CUM
     
-    #culture = english
+    culture = serbian
     religion = orthodox
     
 }

--- a/history/provinces/4239 - Belgrade.txt
+++ b/history/provinces/4239 - Belgrade.txt
@@ -32,6 +32,7 @@ center_of_trade = 1
 
     add_core = HUN
     add_core = SER
+    remove_core = CUM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4268 - Aqaba.txt
+++ b/history/provinces/4268 - Aqaba.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = TBU
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4269 - Al Wajh.txt
+++ b/history/provinces/4269 - Al Wajh.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = TBU
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4270 - Azraq.txt
+++ b/history/provinces/4270 - Azraq.txt
@@ -18,6 +18,15 @@ discovered_by = ottoman
 discovered_by = indian
 discovered_by = nomad_group
 
+1444.11.9 = { 
+
+    add_core = SYR
+    
+    #culture = english
+    #religion = catholic
+    
+}
+
 1515.1.1 = { discovered_by = POR }
 1516.8.24 = {
 	owner = TUR

--- a/history/provinces/4271 - Suwaida.txt
+++ b/history/provinces/4271 - Suwaida.txt
@@ -18,6 +18,15 @@ discovered_by = ottoman
 discovered_by = indian
 discovered_by = nomad_group
 
+1444.11.9 = { 
+
+    add_core = SYR
+    
+    #culture = english
+    #religion = catholic
+    
+}
+
 1515.1.1 = { discovered_by = POR }
 1516.8.24 = {
 	owner = TUR

--- a/history/provinces/4298 - Ayntab.txt
+++ b/history/provinces/4298 - Ayntab.txt
@@ -26,6 +26,7 @@ discovered_by = nomad_group
     controller = DUL
 
     add_core = DUL
+    remove_core = ATC
     
     #culture = english
     religion = sunni

--- a/history/provinces/4307 - Aksaray.txt
+++ b/history/provinces/4307 - Aksaray.txt
@@ -17,3 +17,12 @@ discovered_by = eastern
 discovered_by = muslim
 discovered_by = ottoman
 discovered_by = nomad_group
+
+1444.11.9 = { 
+
+    add_core = ERE
+    
+    #culture = english
+    #religion = catholic
+    
+}

--- a/history/provinces/4312 - Eskesehir.txt
+++ b/history/provinces/4312 - Eskesehir.txt
@@ -24,6 +24,7 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
+    remove_core = OSM
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4316 - Mansura.txt
+++ b/history/provinces/4316 - Mansura.txt
@@ -32,6 +32,7 @@ add_permanent_province_modifier = {
     controller = MAM
 
     add_core = MAM
+    remove_core = TKT
     
     #culture = english
     religion = sunni

--- a/history/provinces/4317 - Buhaira.txt
+++ b/history/provinces/4317 - Buhaira.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = CAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4318 - Atfih.txt
+++ b/history/provinces/4318 - Atfih.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = BNS
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4319 - Isna.txt
+++ b/history/provinces/4319 - Isna.txt
@@ -26,6 +26,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = SAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4320 - Girga.txt
+++ b/history/provinces/4320 - Girga.txt
@@ -27,6 +27,7 @@ discovered_by = east_african
     controller = MAM
 
     add_core = MAM
+    remove_core = SAI
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4538 - Chelm.txt
+++ b/history/provinces/4538 - Chelm.txt
@@ -25,6 +25,8 @@ discovered_by = nomad_group
     controller = POL
 
     add_core = POL
+    add_core = VOL
+    remove_core = VLH
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4539 - Kremenets.txt
+++ b/history/provinces/4539 - Kremenets.txt
@@ -24,6 +24,8 @@ discovered_by = nomad_group
     controller = LIT
 
     add_core = LIT
+    add_core = VOL
+    remove_core = VLH
     
     #culture =  
     religion = orthodox

--- a/history/provinces/4541 - Drohobycz.txt
+++ b/history/provinces/4541 - Drohobycz.txt
@@ -28,6 +28,8 @@ discovered_by = muslim
     controller = POL
 
     add_core = POL
+    add_core = VOL
+    remove_core = GLA
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4700 - Lesbos.txt
+++ b/history/provinces/4700 - Lesbos.txt
@@ -23,6 +23,7 @@ discovered_by = western
     controller = GEN
 
     add_core = GEN
+    remove_core = AEG
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4701 - Corinth.txt
+++ b/history/provinces/4701 - Corinth.txt
@@ -28,6 +28,7 @@ discovered_by = nomad_group
     controller = BYZ
 
     add_core = BYZ
+    remove_core = ATH
     
     #culture = english
     religion = orthodox

--- a/history/provinces/4702 - Siroz.txt
+++ b/history/provinces/4702 - Siroz.txt
@@ -22,6 +22,7 @@ discovered_by = nomad_group
     controller = TUR
     add_core = BYZ
     add_core = TUR
+    remove_core = MAC
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4704 - Tirnovo.txt
+++ b/history/provinces/4704 - Tirnovo.txt
@@ -22,6 +22,8 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
+    add_core = BUL
+    remove_core = KRV
     
     #culture = english
     religion = orthodox

--- a/history/provinces/4705 - Gumulcine.txt
+++ b/history/provinces/4705 - Gumulcine.txt
@@ -21,6 +21,7 @@ discovered_by = nomad_group
     controller = TUR
     add_core = BYZ
     add_core = TUR
+    remove_core = MAC
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4706 - Tolcu.txt
+++ b/history/provinces/4706 - Tolcu.txt
@@ -22,6 +22,8 @@ discovered_by = nomad_group
     controller = TUR
 
     add_core = TUR
+    add_core = BUL
+    remove_core = KRV
     
     #culture = english
     religion = orthodox

--- a/history/provinces/4738 - Trieste.txt
+++ b/history/provinces/4738 - Trieste.txt
@@ -29,6 +29,8 @@ discovered_by = ottoman
     controller = HAB
 
     add_core = HAB
+    add_core = STY
+    remove_core = RIE
     
     #culture = english
     #religion = catholic

--- a/history/provinces/4780 - Ohrid.txt
+++ b/history/provinces/4780 - Ohrid.txt
@@ -30,6 +30,8 @@ discovered_by = nomad_group
 
     add_core = TUR
     add_core = SER
+    add_core = BUL
+    remove_core = SKJ
     
     #culture = english
     #religion = catholic


### PR DESCRIPTION
**Changes:**

- Removed the ahistorical tag of Trieste
- Added some Styria cores
- Removed the Cuman culture from the vanilla start date 
- Removed ahistorical cores of tags Skopje and Macedonia 
- Added Bulgaria's old cores back
- Removed Athenian cores from the Peloponnese
- Removed ahistorical tag Aegea
- Added back vanilla releasables like Saruhan and Galicia–Volhynia 
- Removed Osman from the vanilla start date
- Gave Eretna its vanilla cores back
- Removed Ramazan core on Icel
- Added pontic greek culture and orthodox religion to Sinop and Canik 
- Added greek culture and orthodox religion to Sugla